### PR TITLE
fix #7: nothing is printed for google.com

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -42,8 +42,7 @@ pub(crate) fn cert_chain(host: &str) -> Vec<Certificate> {
     let server_name = ServerName::try_from(host).unwrap();
 
     let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
-    let sock = TcpStream::connect(format!("{host}:443")).unwrap();
-    let mut sock = TlsInspector::new(sock);
+    let mut sock = TcpStream::connect(format!("{host}:443")).unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
 
     tls.write_all(
@@ -65,15 +64,16 @@ Accept-Encoding: identity
     let mut plaintext = Vec::new();
     tls.read_to_end(&mut plaintext).unwrap();
 
-    tls.sock
-        .take_certificates()
-        .map(|der_certs| {
-            der_certs
-                .into_iter()
-                .filter_map(|der| Certificate::from_der(&der.0).ok())
+    // peer_certificates method will return certificates by now
+    // because app data has already been written
+    tls.conn
+        .peer_certificates()
+        .map(|c| {
+            c.iter()
+                .filter_map(|c| Certificate::from_der(&c.0).ok())
                 .collect()
         })
-        .unwrap_or_default()
+        .unwrap_or_else(|| Vec::new())
 }
 
 struct NoopServerCertVerifier;
@@ -90,72 +90,4 @@ impl ServerCertVerifier for NoopServerCertVerifier {
     ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
         Ok(rustls::client::ServerCertVerified::assertion())
     }
-}
-
-struct TlsInspector {
-    inner: TcpStream,
-    buf: Vec<u8>,
-
-    certificates: Option<CertificatePayload>,
-}
-
-impl TlsInspector {
-    fn new(inner: TcpStream) -> Self {
-        Self {
-            inner,
-            buf: Vec::new(),
-            certificates: None,
-        }
-    }
-
-    fn take_certificates(&mut self) -> Option<CertificatePayload> {
-        self.buf = Vec::new();
-        self.certificates.take()
-    }
-}
-
-impl io::Read for TlsInspector {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let res = self.inner.read(buf);
-
-        if self.certificates.is_none() {
-            self.buf.extend(&*buf);
-            self.certificates = parse_certs(&self.buf);
-        }
-
-        res
-    }
-}
-
-impl io::Write for TlsInspector {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.inner.flush()
-    }
-}
-
-fn parse_certs(data: &[u8]) -> Option<CertificatePayload> {
-    let mut reader = Reader::init(data);
-
-    while let Ok(msg) = OpaqueMessage::read(&mut reader) {
-        let msg = Message::try_from(msg.into_plain_message()).ok()?;
-
-        if let MessagePayload::Handshake {
-            parsed:
-                HandshakeMessagePayload {
-                    payload: HandshakePayload::Certificate(mut certs),
-                    ..
-                },
-            ..
-        } = msg.payload
-        {
-            certs.retain(|cert| !cert.0.is_empty());
-            return Some(certs);
-        }
-    }
-
-    None
 }


### PR DESCRIPTION
This commit removes manual parsing done in TlsInspector because the parsing sometimes failed to parse certificates from google.com. Instead the code now gets the certificates by calling the peer_connections method of the TLS connection. This not only fixes the bug but also reduces the code we have to maintain.

closes #7 