### PR TITLE
add support for CRL DP extension

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -5,7 +5,7 @@ use ct_sct::sct;
 use der::Decode;
 use itertools::Itertools;
 use x509_cert::ext::{
-    pkix::{self, name::GeneralName, AuthorityKeyIdentifier},
+    pkix::{self, crl::dp::DistributionPoint, name::GeneralName, AuthorityKeyIdentifier},
     Extension,
 };
 
@@ -21,6 +21,7 @@ pub(crate) fn interpret_val(ext: &Extension) -> String {
         pkix::KeyUsage::OID => fmt_key_usage(ext),
         pkix::ExtendedKeyUsage::OID => fmt_extended_key_usage(ext),
         pkix::AuthorityKeyIdentifier::OID => fmt_authority_key_identifier(ext),
+        pkix::CrlDistributionPoints::OID => fmt_crl_distribution_points(ext),
         sct::SctList::OID => fmt_sct_list(ext),
         _ => openssl_hex(ext.extn_value.as_bytes(), 80).join("\n    "),
     }
@@ -85,6 +86,82 @@ fn fmt_aki_serial(aki: &AuthorityKeyIdentifier) -> String {
         )
     } else {
         String::new()
+    }
+}
+
+fn fmt_crl_distribution_points(ext: &Extension) -> String {
+    let crl_dp = pkix::CrlDistributionPoints::from_der(ext.extn_value.as_bytes()).unwrap();
+    crl_dp.0.iter().map(fmt_crl_distribution_point).join(", ")
+}
+
+fn fmt_crl_distribution_point(dp: &DistributionPoint) -> String {
+    let name = fmt_dp_name(dp);
+    let issuer = fmt_dp_crl_issuer(dp);
+    let reason = fmt_dp_reasons(dp);
+    format!("{name}{issuer}{reason}")
+}
+
+fn fmt_dp_name(dp: &DistributionPoint) -> String {
+    if let Some(ref dp_name) = dp.distribution_point {
+        match dp_name {
+            pkix::name::DistributionPointName::FullName(names) => {
+                format!(
+                    "FullName:\n      {}",
+                    names.iter().map(fmt_general_name).join(", ")
+                )
+            }
+            pkix::name::DistributionPointName::NameRelativeToCRLIssuer(name) => {
+                format!("RelativeName:\n      {name}")
+            }
+        }
+    } else {
+        String::new()
+    }
+}
+
+fn fmt_dp_crl_issuer(dp: &DistributionPoint) -> String {
+    if let Some(ref issuer) = dp.crl_issuer {
+        format!(
+            "{}Issuer: {}",
+            if dp.distribution_point.is_some() {
+                "\n    "
+            } else {
+                "    "
+            },
+            issuer.iter().map(fmt_general_name).join(", ")
+        )
+    } else {
+        String::new()
+    }
+}
+
+fn fmt_dp_reasons(dp: &DistributionPoint) -> String {
+    if let Some(ref reasons) = dp.reasons {
+        format!(
+            "{}Reasons: {}",
+            if dp.distribution_point.is_some() || dp.crl_issuer.is_some() {
+                "\n    "
+            } else {
+                "    "
+            },
+            reasons.into_iter().map(fmt_reason).join(", ")
+        )
+    } else {
+        String::new()
+    }
+}
+
+fn fmt_reason(reason: pkix::crl::dp::Reasons) -> &'static str {
+    match reason {
+        pkix::crl::dp::Reasons::Unused => "Unused",
+        pkix::crl::dp::Reasons::KeyCompromise => "KeyCompromise",
+        pkix::crl::dp::Reasons::CaCompromise => "CaCompromise",
+        pkix::crl::dp::Reasons::AffiliationChanged => "AffiliationChanged",
+        pkix::crl::dp::Reasons::Superseded => "Superseded",
+        pkix::crl::dp::Reasons::CessationOfOperation => "CessationOfOperation",
+        pkix::crl::dp::Reasons::CertificateHold => "CertificateHold",
+        pkix::crl::dp::Reasons::PrivilegeWithdrawn => "PrivilegeWithdrawn",
+        pkix::crl::dp::Reasons::AaCompromise => "AaCompromise",
     }
 }
 


### PR DESCRIPTION
This PR adds support for the [CRL distribution points](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.13) extension. Instead of printing raw bytes for `cargo run -- hashrust.com`:

```
  ID: CRL Distribution Points
  Extension value:
    30:33:30:31:a0:2f:a0:2d:86:2b:68:74:74:70:3a:2f:2f:63:72:6c:2e:69:64:65:6e:74:72:75:73:74:2e:63:6f:6d:2f:44:53:54:52:4f:4f:54:43:41:58:33:43:52:4c:2e:63:72:6c
```

It now prints:

```
  ID: CRL Distribution Points
  Extension value:
    FullName:
      URI:http://crl.identrust.com/DSTROOTCAX3CRL.crl
```

It also prints the `issuer` and `reasons` fields if present:

```
  ID: CRL Distribution Points
  Extension value:
    FullName:
      URI:http://example.com/myca.crl
    Issuer: DIR:C=UK,O=Organisation,CN=Some Name
    Reasons: KeyCompromise, CaCompromise
```

A test certificate containing `issuer` and `reason` fields:

```
-----BEGIN CERTIFICATE-----
MIIGUDCCBDigAwIBAgIUdTVO2VyRRxURaqnHU3NSF34P6uowDQYJKoZIhvcNAQEL
BQAwXzELMAkGA1UEBhMCSU4xDzANBgNVBAgMBlBVTkpBQjEPMA0GA1UEBwwGTU9I
QUxJMQ8wDQYDVQQKDAZHaXRodWIxDDAKBgNVBAsMA0RldjEPMA0GA1UEAwwGUm9v
dENBMB4XDTIzMDYxMDE2NTEwOFoXDTI0MDYwOTE2NTEwOFowZDELMAkGA1UEBhMC
SU4xEjAQBgNVBAgMCUtBUk5BVEFLQTESMBAGA1UEBwwJQkFOR0FMT1JFMQ8wDQYD
VQQKDAZHaXRodWIxDDAKBgNVBAsMA0RldjEOMAwGA1UEAwwFVmVub20wggIiMA0G
CSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCcsFzLB4h0eILcdd7d+ch0nykZWt2K
U8mGjQ2TvJVpg0OtjWDyWQVSMFL+hVckVoGqwBPBOkEWxuhUSEQd0N/prsyKhAHi
mPTHHVUTvYPaCJSKcGiP9r/8DtXzWsCC76iLUerLhBuCXbWC7t1WbsKOeurOoxpw
L8Yjk7PM/MIsBaOJgnIQVM9lU3+xMRdQhoPBr5rBs9Ev6LbnilZmg1W5dCnIdLmA
c4doqAOx7Ft4GGAaa+d7PFszshYH7pbcKsmFcYcxNewz6GV7XLy/ewlof1TC9lL1
tGF4cvwo5BmyfgWmx3ityaJfIpUzDKDKAZBURLmJ3dsYp+lBT/xpn9/YTDLRqoFz
FxY1lqNazAPZ+wrBdqKX02hf8goJnmpMw2turtjX4z4aGBlktlxcXniQ2QzFUcum
iLlD0QEJvJQNV8/4WchJg4vnslJFKgHZFEC+4RrKKiwZFFQmsBtBTj7XkVvq6TPm
lkXtt0LIFYsakDqfySewwBzZ/ZL0gUm/qpSVcwSirAuJf8++rRML9O7KAxTpIFh5
arnNjQrsjbUEri9LB3AcNtiYNz/0k7caFrHGI3qm17vEJZ+JUlQzHnSJR21er3Eo
43geA/VHLO2e0Mvv4eZDC6k2XLFNK0yy0zR/afFWv11cjzsrjUtS1pakNHC/pSU4
GSvZExp01KoR8QIDAQABo4H+MIH7MAkGA1UdEwQCMAAwMQYDVR0lBCowKAYIKwYB
BQUHAwEGCCsGAQUFBwMCBggrBgEFBQcDAwYIKwYBBQUHAwQwCwYDVR0PBAQDAgXg
MG4GA1UdHwRnMGUwY6AfoB2GG2h0dHA6Ly9leGFtcGxlLmNvbS9teWNhLmNybIEC
BWCiPKQ6MDgxCzAJBgNVBAYTAlVLMRUwEwYDVQQKDAxPcmdhbmlzYXRpb24xEjAQ
BgNVBAMMCVNvbWUgTmFtZTAdBgNVHQ4EFgQUx2P7/J5zEtq+clqHypbCn7258xAw
HwYDVR0jBBgwFoAUvlQL8v85LpCxH+T5hqUjLL0ahZowDQYJKoZIhvcNAQELBQAD
ggIBAA8ghx8zn8Ipy9j5t7i3Wdd5ePy72XCF7ynyKjIvYs8U11ll3zfCQQU4YRUv
3IxeAsru97xnw3gS6/zVUbhMSRJhshi2pr4MOnhJN9VTkKDh6wiOJGzi4l+wNjsU
f5OxY+sYWPDEity4gJMzJa7gZtmgtPJ2xzQLWhKaAD7mX/pfA1jt+fNFnjkZpk72
z3FgFnEW5rU64GvDDdO83CfOWJyOosw1cAkPkyHOlbZ6WearTrF5g7ciOAJOAqm3
lojFgoeY3CTWHG7RAyUBC7t+6yTWPcBO7lRixLM3ekLHZVyT7LSYdipO2l7mjF4q
1BGHOMoY2T9IkrzfuEpYI7GKglOzw5zDIUq9MZuzrWH/8P9BEGMZm6VJGp1NlXeM
1jwJRrK4JvjxRGhnOKiy0T9FcJlBD0ARne4afEoDLwu9R3nxkSEDJrUlwkDLiL7s
67bevMnjK4miBUnqKmxztcCUm84eeiiaG9H17Z9EeA5tyZwAAIW/RkemmXbeS3SF
7TKVmcBfAB4NAqv9ksHDatPWONLP5tNeY0i2zdltB92KJ5Xigdlw8MagKKiRE5PN
oaULLtOWvIs3CIU/qNdj53zaW1162GyNtU8j7UTqVNn9OYEe3HMG4zvIH7/1H9nS
VN1YLaYwgoo2UXzQBxlii5XFnrYae2Kf1n5JMx54ObqlH6BB
-----END CERTIFICATE-----
```