### PR TITLE
do not print Some(x) for path length constraint

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,4 +1,7 @@
-use std::net::{IpAddr, Ipv4Addr};
+use std::{
+    borrow::Cow,
+    net::{IpAddr, Ipv4Addr},
+};
 
 use const_oid::{db::DB, AssociatedOid as _, ObjectIdentifier};
 use ct_sct::sct;
@@ -127,9 +130,12 @@ fn fmt_authority_info_access_syntax(ext: &Extension) -> String {
 
 fn fmt_basic_constraints(ext: &Extension) -> String {
     let constraints = pkix::BasicConstraints::from_der(ext.extn_value.as_bytes()).unwrap();
+    let path_len = constraints
+        .path_len_constraint
+        .map_or(Cow::Borrowed("None"), |c| Cow::Owned(format!("{c}")));
     format!(
-        "CA: {}\n    Path Length Constraint: {:?}",
-        constraints.ca, constraints.path_len_constraint
+        "CA: {}\n    Path Length Constraint: {path_len}",
+        constraints.ca
     )
 }
 


### PR DESCRIPTION
For basic constraints extension's `Path Length Constraint` field, this PR now prints:

```
  ID: Basic Constraints (critical)
  Extension value:
    CA: true
    Path Length Constraint: 0
```

Instead of printing:

```
  ID: Basic Constraints (critical)
  Extension value:
    CA: true
    Path Length Constraint: Some(0)
```

If `Path Length Constraint` is missing it still prints `None`.