### PR TITLE
chore(deps): upgrade RustCrypto certificate stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,7 +578,17 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
  "der_derive",
  "flagset",
  "pem-rfc7468",
@@ -581,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -964,9 +980,9 @@ dependencies = [
  "chrono",
  "clap",
  "color-eyre",
- "const-oid",
+ "const-oid 0.10.2",
  "crossterm",
- "der",
+ "der 0.8.1",
  "error_reporter",
  "eyre",
  "itertools 0.15.0",
@@ -1479,9 +1495,9 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -1599,9 +1615,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
+ "der 0.7.10",
  "pkcs8",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1610,8 +1626,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2140,7 +2156,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -3078,13 +3104,13 @@ checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "x509-cert"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
 dependencies = [
- "const-oid",
- "der",
- "spki",
+ "const-oid 0.10.2",
+ "der 0.8.1",
+ "spki 0.8.0",
  "tls_codec",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ cfg-if = "1"
 chrono = "0.4.45"
 clap = { version = "4", features = ["derive"] }
 color-eyre = "0.6"
-const-oid = { version = "0.9.6", features = ["std", "db"] }
+const-oid = { version = "0.10", features = ["db"] }
 crossterm = "0.29"
-der = { version = "0.7", features = ["std"] }
+der = { version = "0.8", features = ["std"] }
 error_reporter = "1"
 eyre = "0.6"
 itertools = "0.15"
-pem-rfc7468 = { version = "0.7", features = ["std"] }
+pem-rfc7468 = { version = "1", features = ["std"] }
 pkcs1 = { version = "0.7", features = ["std"] }
 ratatui = "0.30"
 rustls = "0.23"
@@ -33,7 +33,7 @@ rustls-pki-types = "1"
 rustls-platform-verifier = "0.7"
 tracing = { version = "0.1.44", features = ["log", "release_max_level_debug"] }
 tracing-subscriber = "0.3"
-x509-cert = { version = "0.2.5", features = ["sct"] }
+x509-cert = { version = "0.3", features = ["sct"] }
 yansi = "1"
 
 [profile.release]

--- a/src/info.rs
+++ b/src/info.rs
@@ -6,8 +6,8 @@ use const_oid::{
     db::rfc5912::{ID_EC_PUBLIC_KEY, RSA_ENCRYPTION},
 };
 use crossterm::style::Stylize as _;
-use der::Decode as _;
 use itertools::Itertools as _;
+use pkcs1::der::Decode as _;
 use x509_cert::Certificate;
 
 use crate::{ext, util};
@@ -17,43 +17,43 @@ pub(crate) fn write_cert_info(
     mut wrt: impl io::Write,
     stylize: bool,
 ) -> io::Result<()> {
-    let tbs = &cert.tbs_certificate;
+    let tbs = cert.tbs_certificate();
 
-    let tbs_cert = &tbs;
+    let tbs_cert = tbs;
     writeln!(
         wrt,
         "Subject: {}",
-        tbs_cert.subject.to_string().yellow().bold()
+        tbs_cert.subject().to_string().yellow().bold()
     )?;
 
-    writeln!(wrt, "Issuer: {}", tbs.issuer.to_string().blue().bold())?;
+    writeln!(wrt, "Issuer: {}", tbs.issuer().to_string().blue().bold())?;
 
-    writeln!(wrt, "Version: {:?}", tbs.version)?;
+    writeln!(wrt, "Version: {:?}", tbs.version())?;
     writeln!(
         wrt,
         "Serial Number:\n  {}",
-        util::openssl_hex(tbs.serial_number.as_bytes(), 20).join("\n  ")
+        util::openssl_hex(tbs.serial_number().as_bytes(), 20).join("\n  ")
     )?;
 
     writeln!(
         wrt,
         "Signature Algorithm: {}",
-        util::oid_desc_or_raw(&cert.signature_algorithm.oid)
+        util::oid_desc_or_raw(&cert.signature_algorithm().oid)
     )?;
-    util::assert_null_params(&cert.signature_algorithm);
+    util::assert_null_params(cert.signature_algorithm());
 
     // TODO: doesn't work ?
     writeln!(
         wrt,
         "Issuer Serial Number:\n  {}",
-        tbs.issuer_unique_id
+        tbs.issuer_unique_id()
             .as_ref()
             .map(|serial| util::openssl_hex(serial.as_bytes().unwrap(), 20).join("\n  "))
             .unwrap_or_else(|| "<unknown>".to_owned())
     )?;
 
-    let (nbf, nbf_in_future) = util::duration_since_now_fmt(tbs.validity.not_before);
-    let (exp, exp_in_future) = util::duration_since_now_fmt(tbs.validity.not_after);
+    let (nbf, nbf_in_future) = util::duration_since_now_fmt(tbs.validity().not_before);
+    let (exp, exp_in_future) = util::duration_since_now_fmt(tbs.validity().not_after);
 
     writeln!(
         wrt,
@@ -72,7 +72,7 @@ pub(crate) fn write_cert_info(
     writeln!(
         wrt,
         "  Not Before: {} ({})",
-        tbs.validity.not_before,
+        tbs.validity().not_before,
         if stylize {
             if nbf_in_future {
                 nbf.red().bold()
@@ -87,7 +87,7 @@ pub(crate) fn write_cert_info(
     writeln!(
         wrt,
         "  Not After: {} ({})",
-        tbs.validity.not_after,
+        tbs.validity().not_after,
         if stylize {
             if exp_in_future {
                 exp.green().bold()
@@ -105,7 +105,7 @@ pub(crate) fn write_cert_info(
 
     writeln!(wrt, "Subject Public Key Info:")?;
 
-    let spki = &tbs_cert.subject_public_key_info;
+    let spki = tbs_cert.subject_public_key_info();
     let alg = &spki.algorithm;
 
     match () {
@@ -154,7 +154,7 @@ pub(crate) fn write_cert_info(
         }
     }
 
-    if let Some(extensions) = &tbs.extensions {
+    if let Some(extensions) = tbs.extensions() {
         writeln!(wrt, "Extensions:")?;
 
         for ext in extensions {
@@ -173,7 +173,7 @@ pub(crate) fn write_cert_info(
     writeln!(
         wrt,
         "  {}",
-        util::openssl_hex(cert.signature.as_bytes().unwrap(), 20).join("\n  ")
+        util::openssl_hex(cert.signature().as_bytes().unwrap(), 20).join("\n  ")
     )?;
 
     Ok(())

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -134,7 +134,7 @@ impl App {
         let list = self
             .certs
             .iter()
-            .map(|(cert, _, _)| cert.tbs_certificate.subject.to_string())
+            .map(|(cert, _, _)| cert.tbs_certificate().subject().to_string())
             .collect::<List<'static>>();
 
         let instructions = Line::from(vec![
@@ -214,8 +214,8 @@ impl App {
             event::KeyCode::Char('p') if ev.modifiers.contains(KeyModifiers::CONTROL) => {
                 let spki = &self.certs[selected]
                     .0
-                    .tbs_certificate
-                    .subject_public_key_info
+                    .tbs_certificate()
+                    .subject_public_key_info()
                     .to_pem(LINE_ENDING)
                     .expect("SPKI should encode to PEM successfully");
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,40 +1,9 @@
-#![allow(unused)]
-
-use std::io::Read;
-
-use chrono::TimeZone as _;
 use const_oid::{
     ObjectIdentifier,
-    db::{DB, Database, rfc5280, rfc5912, rfc6962},
+    db::{DB, rfc5280, rfc5912, rfc6962},
 };
 use itertools::Itertools as _;
-use x509_cert::spki::{AlgorithmIdentifier, AlgorithmIdentifierOwned};
-
-/// Taken from <https://github.com/rustls/rustls/blob/a71223c4/rustls/src/x509.rs>.
-pub(crate) fn wrap_in_asn1_len(bytes: &mut Vec<u8>) {
-    let len = bytes.len();
-
-    if len <= 0x7f {
-        bytes.insert(0, len as u8);
-    } else {
-        bytes.insert(0, 0x80u8);
-        let mut left = len;
-        while left > 0 {
-            let byte = (left & 0xff) as u8;
-            bytes.insert(1, byte);
-            bytes[0] += 1;
-            left >>= 8;
-        }
-    }
-}
-
-/// Prepend stuff to `bytes` to put it in a DER SEQUENCE.
-///
-/// Taken from <https://github.com/rustls/rustls/blob/a71223c4/rustls/src/x509.rs>.
-pub(crate) fn wrap_in_sequence(bytes: &mut Vec<u8>) {
-    wrap_in_asn1_len(bytes);
-    bytes.insert(0, u8::from(der::Tag::Sequence));
-}
+use x509_cert::spki::AlgorithmIdentifierOwned;
 
 #[track_caller]
 pub(crate) fn assert_null_params(alg: &AlgorithmIdentifierOwned) {


### PR DESCRIPTION
## Summary

- combine the dependency updates from #444 and #445
- upgrade `der` to 0.8.1 and `x509-cert` to 0.3.0 together
- align the directly used `const-oid` and `pem-rfc7468` crates with the new RustCrypto stack
- migrate certificate and TBS certificate field access to the new accessor API
- keep RSA public-key decoding on `pkcs1`'s matching DER trait generation
- remove unused ASN.1 sequence helpers and stale imports instead of carrying dead compatibility code

## Why

The two Dependabot PRs split a coupled major-version migration. Updating only one crate leaves incompatible `der`, `const-oid`, and PEM trait generations in use, so certificate parsing and encoding fail to compile. The `x509-cert` 0.3 changelog also documents that certificate fields are now private.

The upgrade initially exposed an old, unused DER sequence helper copied from rustls. Removing the module-level unused-code suppression showed that the helper had no production call sites, so this PR removes it and the stale imports rather than maintaining another DER encoder.

## Changelog review

- `der` 0.8 moves to `const-oid` 0.10 and changes parts of the tag/decoder API; 0.8.1 also caps nested messages at 64
- `x509-cert` 0.3 makes `CertificateInner` and `TbsCertificateInner` fields private and moves to `der` 0.8 / `spki` 0.8
- `const-oid` 0.10 removes the `std` feature
- `pem-rfc7468` 1.0 is the compatible PEM trait generation used by `der` 0.8

Supersedes #444 and #445.

## Validation

- `just clippy` (no warnings)
- `just test`
- `cargo +nightly fmt -- --check`
- `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --workspace --no-deps --all-features`
- `cargo run --quiet -- --file roots/ietf-org-chain.pem`
