### PR TITLE
ci: check project formatting with Nix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,10 +35,13 @@ jobs:
       - name: Check with Clippy
         run: just clippy
 
-  rustfmt:
+  project-format:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
 
       - name: Install Rust (nightly)
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
@@ -46,8 +49,16 @@ jobs:
           toolchain: nightly
           components: rustfmt
 
-      - name: Check with Rustfmt
-        run: cargo fmt -- --check
+      - name: Enter Nix devshell
+        uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci-format
+
+      - name: Format project
+        run: just fmt
+
+      - name: Check formatting diff
+        run: git diff --exit-code
 
   docs:
     runs-on: blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check with Clippy
         run: just clippy
 
-  project-format:
+  format:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,16 @@
             doCheck = true;
           };
 
+          devShells.ci-format = pkgs.mkShell {
+            packages = [
+              config.formatter
+              pkgs.fd
+              pkgs.just
+              pkgs.prettier
+              pkgs.taplo
+            ];
+          };
+
           devShells.default = pkgs.mkShell {
             buildInputs = [ x52just ];
 


### PR DESCRIPTION
## Summary

- add a focused `ci-format` devshell containing only the repository formatting tools
- install upstream Nix with the quick single-user installer
- keep `nicknovitski/nix-develop` as a separate setup step
- replace the Rustfmt-only lint job with full repository formatting
- use no additional Nix cache

## Why

The existing Blacksmith job checks only Rust formatting. This applies the fastest repeatable Nix setup measured in xwc while expanding coverage to the Justfile, Nix, Markdown, YAML, TOML, and Rust sources through `just fmt`.

The native Linux, macOS, and Windows test and release jobs remain unchanged.

## Timing

| Configuration | Samples | Median |
| --- | --- | ---: |
| Blacksmith Rustfmt-only baseline | 18s, 19s | 18.5s |
| Blacksmith full project formatting | 26s, 22s, 22s | **22s** |

The broader formatting check adds approximately 3.5 seconds at the median. Across the three new samples, installing Nix took 0–1 seconds and entering the devshell took 6–8 seconds.

## Validation

- `nix develop .#ci-format -c just fmt`
- `nix flake check --no-build --all-systems`
- `git diff --check`
- three successful Blacksmith format-job samples
- all GitHub Actions checks pass on Linux, macOS, and Windows
