### PR TITLE
ci: update Homebrew tap after releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,3 +158,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASES_JSON: ${{ needs.release.outputs.releases }}
         run: x52-comment-release-assets-uploaded "$RELEASES_JSON" "$GITHUB_SHA"
+
+      - name: Create Homebrew tap token
+        id: homebrew-tap-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.HOMEBREW_TAP_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: x52dev
+          repositories: homebrew-tap
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Update Homebrew tap
+        env:
+          GH_TOKEN: ${{ steps.homebrew-tap-token.outputs.token }}
+          RELEASES_JSON: ${{ needs.release.outputs.releases }}
+        run: x52-update-homebrew-tap --releases "$RELEASES_JSON" --package inspect-cert-chain

--- a/flake.lock
+++ b/flake.lock
@@ -127,11 +127,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786283360,
-        "narHash": "sha256-rqhvckgKYV8dOuvLRaezUxkUGDpG4cAuhrZvmR6AeM4=",
+        "lastModified": 1786294735,
+        "narHash": "sha256-gCixQlBI3eyTLnQhGV49mZpRoaLKQwfG2H+4EYuuCrA=",
         "owner": "x52dev",
         "repo": "nix",
-        "rev": "f9e2610953f406d602b4b62abc435805ab77162e",
+        "rev": "3c71dd60547f370b9b96bedb51d00db571c9774e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,10 @@
           };
 
           devShells.ci-release = pkgs.mkShellNoCC {
-            packages = [ inputs'.x52.packages.x52-release-tools ];
+            packages = [
+              pkgs.cargo
+              inputs'.x52.packages.x52-release-tools
+            ];
           };
         };
     };


### PR DESCRIPTION
## Summary

- run the shared Homebrew tap updater after all release assets upload
- mint a short-lived GitHub App token scoped to `x52dev/homebrew-tap`
- provide Cargo in the release shell for Formula metadata rendering
- update the shared release-tools lock to the checksum-compatible revision

Configure the organization variable `HOMEBREW_TAP_APP_CLIENT_ID` and secret `HOMEBREW_TAP_APP_PRIVATE_KEY`, restricted to `inspect-cert-chain`. The app must be installed only on `x52dev/homebrew-tap` with Contents and Pull requests write access.

## Validation

- `nix develop -c just check`
- `nix flake check path:.`