### PR TITLE
ci: update Homebrew tap after publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,20 +158,3 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASES_JSON: ${{ needs.release.outputs.releases }}
         run: x52-comment-release-assets-uploaded "$RELEASES_JSON" "$GITHUB_SHA"
-
-      - name: Create Homebrew tap token
-        id: homebrew-tap-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.HOMEBREW_TAP_APP_CLIENT_ID }}
-          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
-          owner: x52dev
-          repositories: homebrew-tap
-          permission-contents: write
-          permission-pull-requests: write
-
-      - name: Update Homebrew tap
-        env:
-          GH_TOKEN: ${{ steps.homebrew-tap-token.outputs.token }}
-          RELEASES_JSON: ${{ needs.release.outputs.releases }}
-        run: x52-update-homebrew-tap --releases "$RELEASES_JSON" --package inspect-cert-chain

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -1,0 +1,45 @@
+name: Update Homebrew tap
+
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  update-homebrew-tap:
+    name: Update Homebrew tap
+    if: ${{ github.repository_owner == 'x52dev' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+
+      - name: Enter Nix devshell
+        uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1.2.1
+        with:
+          arguments: .#ci-release
+
+      - name: Create Homebrew tap token
+        id: homebrew-tap-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.HOMEBREW_TAP_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: x52dev
+          repositories: homebrew-tap
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Update Homebrew tap
+        env:
+          GH_TOKEN: ${{ steps.homebrew-tap-token.outputs.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: x52-update-homebrew-tap --tag "$RELEASE_TAG" --package inspect-cert-chain

--- a/flake.lock
+++ b/flake.lock
@@ -127,11 +127,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786294735,
-        "narHash": "sha256-gCixQlBI3eyTLnQhGV49mZpRoaLKQwfG2H+4EYuuCrA=",
+        "lastModified": 1786298533,
+        "narHash": "sha256-HypAuRbExb1lwR09iqK5X4SYXvJIq74bikwhXkYumqw=",
         "owner": "x52dev",
         "repo": "nix",
-        "rev": "3c71dd60547f370b9b96bedb51d00db571c9774e",
+        "rev": "ab12f8ac927aad1f76de1b439db717625e3cad53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Moves the Homebrew tap updater out of the draft-release asset workflow.

The new workflow runs only when GitHub publishes a release and uses the published release tag directly. It keeps the GitHub App token scoped to the tap repository, while the workflow checkout receives only `contents: read`.

The flake lock includes the Git authentication fix merged in x52dev/nix#16.

Validation: `nix develop -c just check`.
