### PR TITLE
fix: pass version to Homebrew updater

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -42,4 +42,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.homebrew-tap-token.outputs.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: x52-update-homebrew-tap --tag "$RELEASE_TAG" --package inspect-cert-chain
+        run: >-
+          x52-update-homebrew-tap --package inspect-cert-chain
+          --version "${RELEASE_TAG#v}" --tag "$RELEASE_TAG"


### PR DESCRIPTION
Pass the released package version to the Homebrew updater when it runs after a published release.

The workflow previously passed only the tag. The updater intentionally requires `--tag` with `--version` for manual release input. This repository uses `v<semver>` tags, so the workflow removes the leading `v` before passing the version.

The updater arguments are ordered as package, version, then tag.

Validation: `nix develop -c just check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the automated Homebrew tap update process to pass release versions more reliably.
  * Preserved existing package and tag update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->