### PR TITLE
ci: use authenticated Homebrew tap checkout

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -38,10 +38,19 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
+      - name: Check out Homebrew tap
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: x52dev/homebrew-tap
+          token: ${{ steps.homebrew-tap-token.outputs.token }}
+          path: homebrew-tap
+          persist-credentials: true
+
       - name: Update Homebrew tap
         env:
           GH_TOKEN: ${{ steps.homebrew-tap-token.outputs.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          X52_HOMEBREW_TAP_DIRECTORY: ${{ github.workspace }}/homebrew-tap
         run: >-
           x52-update-homebrew-tap --package inspect-cert-chain
           --version "${RELEASE_TAG#v}" --tag "$RELEASE_TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - Pass version to Homebrew updater ([#484](https://github.com/x52dev/inspect-cert-chain/pull/484))
 
-
 ## 0.0.33
 
 - No significant changes since 0.0.32.

--- a/flake.lock
+++ b/flake.lock
@@ -127,11 +127,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786298533,
-        "narHash": "sha256-HypAuRbExb1lwR09iqK5X4SYXvJIq74bikwhXkYumqw=",
+        "lastModified": 1786328239,
+        "narHash": "sha256-ttcVfFssqTwMlrvLo4A8z0mMS7waHVyBV13hZ/cfdrM=",
         "owner": "x52dev",
         "repo": "nix",
-        "rev": "ab12f8ac927aad1f76de1b439db717625e3cad53",
+        "rev": "4253f74552b9a5dca45ffc89b7d14f5ce7d629f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Checks out `x52dev/homebrew-tap` with the scoped GitHub App token before running the shared updater. The checkout owns Git authentication and persists it only for that tap working tree; the updater uses ordinary Git commands there. The same installation token remains in `GH_TOKEN` for release downloads and `gh pr create`.

Pins the merged x52dev/nix#17 commit, which makes the prepared tap checkout a documented requirement and removes manual credential-helper and HTTP-header handling from the updater.

Validation:

- `nix develop -c just check`
- `nix flake check path:.`
- `nix develop .#ci-release -c x52-update-homebrew-tap --help`
- `zizmor .github/workflows/update-homebrew-tap.yml`